### PR TITLE
Fix history data caching and tests

### DIFF
--- a/ID.WeatherDashboard.API/Services/DataRetrieverService.cs
+++ b/ID.WeatherDashboard.API/Services/DataRetrieverService.cs
@@ -595,6 +595,7 @@ namespace ID.WeatherDashboard.API.Services
                 SetElement(config, cond, wc, $"{nameof(DataLine.WeatherConditions)}.{nameof(WeatherConditions.IsTornado)}", (sl, b) => sl.IsTornado = b, sl => sl?.IsTornado);
                 SetElement(config, cond, wc, $"{nameof(DataLine.WeatherConditions)}.{nameof(WeatherConditions.StateConditions)}", (sl, b) => sl.StateConditions = b, sl => sl?.StateConditions);
                 SetElement(config, cond, wc, $"{nameof(DataLine.WeatherConditions)}.{nameof(WeatherConditions.Latitude)}", (sl, b) => sl.Latitude = b, sl => sl?.Latitude);
+                historyData.AddLine(baseLine);
 
                 lines.Add(baseLine);
             }


### PR DESCRIPTION
## Summary
- ensure history lines are added when retrieving history data
- expand history data tests to validate lines and overlay behavior

## Testing
- `dotnet test ID.WeatherDashboard.APITests/ID.WeatherDashboard.APITests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687a3599c3a48320905d6a7c7cad4832