### PR TITLE
Add comprehensive history data tests

### DIFF
--- a/ID.WeatherDashboard.APITests/Services/DataRetrieverServiceTests_History.cs
+++ b/ID.WeatherDashboard.APITests/Services/DataRetrieverServiceTests_History.cs
@@ -1,6 +1,7 @@
 ﻿using ID.WeatherDashboard.API.Codes;
 using ID.WeatherDashboard.API.Data;
 using ID.WeatherDashboard.API.Services;
+using ID.WeatherDashboard.API.Config;
 using Moq;
 
 namespace ID.WeatherDashboard.APITests.Services
@@ -275,6 +276,301 @@ namespace ID.WeatherDashboard.APITests.Services
             historyService.Verify(s => s.GetHistoryDataAsync(It.IsAny<Location>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()), Times.Exactly(2));
             Assert.AreEqual(2, HistoryDataUpdated.Count, "Expected HistoryDataUpdated event to fire twice.");
         }
+
+        [TestMethod]
+        public async Task GetHistoryDataAsync_ShouldMergeLinesWithSameObservedDate()
+        {
+            var service1 = SetupHistoryQueryService("HistoryService1");
+            var service2 = SetupHistoryQueryService("HistoryService2");
+
+            var observed = DateTimeOffset.Now.Date.AddHours(1);
+
+            var line1 = GenerateHistoryLine(observed: observed);
+            var line2 = GenerateHistoryLine(observed: observed);
+
+            service1.Setup(s => s.GetHistoryDataAsync(It.IsAny<Location>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
+                .ReturnsAsync(new HistoryData(DateTimeOffset.Now, line1));
+            service2.Setup(s => s.GetHistoryDataAsync(It.IsAny<Location>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
+                .ReturnsAsync(new HistoryData(DateTimeOffset.Now, line2));
+
+            Config.HistoryData = GenerateAllStarConfig("HistoryService1", "HistoryService2");
+
+            var dr = GetDataRetriever();
+            var l = new Location("TestLocation");
+
+            var result = await dr.GetHistoryDataAsync(l);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.Lines.Count(l => l.Observed == observed), "Expected merged line for shared observed date.");
+        }
+
+        [TestMethod]
+        public async Task GetHistoryDataAsync_ShouldOverlayWeatherConditionsCorrectly()
+        {
+            var service1 = SetupHistoryQueryService("HistoryService1");
+            var service2 = SetupHistoryQueryService("HistoryService2");
+
+            var observed = DateTimeOffset.Now.Date;
+
+            var line1 = GenerateHistoryLine(observed: observed);
+            line1.WeatherConditions!.IsRain = false;
+            var line2 = GenerateHistoryLine(observed: observed);
+            line2.WeatherConditions!.IsRain = true;
+
+            service1.Setup(s => s.GetHistoryDataAsync(It.IsAny<Location>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
+                .ReturnsAsync(new HistoryData(DateTimeOffset.Now, line1));
+            service2.Setup(s => s.GetHistoryDataAsync(It.IsAny<Location>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
+                .ReturnsAsync(new HistoryData(DateTimeOffset.Now, line2));
+
+            Config.HistoryData = new DataConfig()
+            {
+                OverlayExistingData = true,
+                Elements =
+                [
+                    new ElementConfig
+                    {
+                        Name = $"{nameof(DataLine.WeatherConditions)}.{nameof(WeatherConditions.IsRain)}",
+                        ServiceElements =
+                        [
+                            new ServiceElementConfig{ ServiceName = "HistoryService1", Action = "Override", Weight = 100 },
+                            new ServiceElementConfig{ ServiceName = "HistoryService2", Action = "Override", Weight = 100 }
+                        ]
+                    }
+                ]
+            };
+
+            var dr = GetDataRetriever();
+            var l = new Location("TestLocation");
+
+            var result = await dr.GetHistoryDataAsync(l);
+
+            Assert.IsNotNull(result);
+            var line = result.Lines.FirstOrDefault();
+            Assert.IsNotNull(line);
+            Assert.IsTrue(line.WeatherConditions!.IsRain!.Value, "Expected IsRain from second service to override.");
+        }
+
+        private async Task TestHistoryTemperatureWeighting(string elementName, Action<HistoryLine, Temperature> setValue, Func<HistoryLine, Temperature?> getValue)
+        {
+            var weight1 = TestHelpers.RandomIntBetween(100, 500);
+            var weight2 = TestHelpers.RandomIntBetween(100, 500);
+
+            var service1Name = TestHelpers.RandomString(8, TestHelpers.UppercaseLetters, TestHelpers.LowercaseLetters);
+            var service2Name = TestHelpers.RandomString(8, TestHelpers.UppercaseLetters, TestHelpers.LowercaseLetters);
+
+            var service1 = SetupHistoryQueryService(service1Name);
+            var service2 = SetupHistoryQueryService(service2Name);
+
+            var observed = DateTimeOffset.Now.Date;
+
+            var value1 = TestHelpers.RandomFloatBetween(30, 100);
+            var value2 = TestHelpers.RandomFloatBetween(30, 100);
+
+            var line1 = GenerateFullyFormedHistoryLine(observed: observed);
+            var line2 = GenerateFullyFormedHistoryLine(observed: observed);
+
+            setValue(line1, new Temperature(value1));
+            setValue(line2, new Temperature(value2));
+
+            service1.Setup(s => s.GetHistoryDataAsync(It.IsAny<Location>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
+                .ReturnsAsync(new HistoryData(DateTimeOffset.Now, line1));
+            service2.Setup(s => s.GetHistoryDataAsync(It.IsAny<Location>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
+                .ReturnsAsync(new HistoryData(DateTimeOffset.Now, line2));
+
+            Config.HistoryData = new DataConfig()
+            {
+                OverlayExistingData = true,
+                Elements =
+                [
+                    new ElementConfig
+                    {
+                        Name = elementName,
+                        ServiceElements =
+                        [
+                            new ServiceElementConfig { ServiceName = service1Name, Action = "Average", Weight = weight1 },
+                            new ServiceElementConfig { ServiceName = service2Name, Action = "Average", Weight = weight2 }
+                        ]
+                    }
+                ]
+            };
+
+            var dr = GetDataRetriever();
+            var l = new Location("TestLocation");
+
+            var result = await dr.GetHistoryDataAsync(l);
+
+            Assert.IsNotNull(result);
+            var line = result.Lines.First();
+            var temp = getValue(line);
+            Assert.IsNotNull(temp, $"Expected {elementName} to be set.");
+
+            var expected = ((value1 * weight1) + (value2 * weight2)) / (float)(weight1 + weight2);
+            Assert.AreEqual(expected, temp!.To(TemperatureEnum.Fahrenheit)!.Value, 0.01, $"Weighted average for {elementName} incorrect.");
+        }
+
+        [TestMethod]
+        public async Task GetHistoryDataAsync_ShouldWeightCurrentTemperatureCorrectly()
+        {
+            await TestHistoryTemperatureWeighting(nameof(DataLine.CurrentTemperature), (hl, t) => hl.CurrentTemperature = t, hl => hl.CurrentTemperature);
+        }
+
+        [TestMethod]
+        public async Task GetHistoryDataAsync_ShouldWeightFeelsLikeCorrectly()
+        {
+            await TestHistoryTemperatureWeighting(nameof(DataLine.FeelsLike), (hl, t) => hl.FeelsLike = t, hl => hl.FeelsLike);
+        }
+
+        [TestMethod]
+        public async Task GetHistoryDataAsync_ShouldWeightWeatherConditionsWindSpeedCorrectly()
+        {
+            var weight1 = TestHelpers.RandomIntBetween(100, 500);
+            var weight2 = TestHelpers.RandomIntBetween(100, 500);
+
+            var service1Name = TestHelpers.RandomString(8, TestHelpers.UppercaseLetters, TestHelpers.LowercaseLetters);
+            var service2Name = TestHelpers.RandomString(8, TestHelpers.UppercaseLetters, TestHelpers.LowercaseLetters);
+
+            var service1 = SetupHistoryQueryService(service1Name);
+            var service2 = SetupHistoryQueryService(service2Name);
+
+            var observed = DateTimeOffset.Now.Date;
+
+            var value1 = TestHelpers.RandomFloatBetween(0, 50);
+            var value2 = TestHelpers.RandomFloatBetween(0, 50);
+
+            var line1 = GenerateFullyFormedHistoryLine(observed: observed);
+            var line2 = GenerateFullyFormedHistoryLine(observed: observed);
+
+            line1.WeatherConditions!.WindSpeed = new WindSpeed(value1, WindSpeedEnum.MilesPerHour);
+            line2.WeatherConditions!.WindSpeed = new WindSpeed(value2, WindSpeedEnum.MilesPerHour);
+
+            service1.Setup(s => s.GetHistoryDataAsync(It.IsAny<Location>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
+                .ReturnsAsync(new HistoryData(DateTimeOffset.Now, line1));
+            service2.Setup(s => s.GetHistoryDataAsync(It.IsAny<Location>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
+                .ReturnsAsync(new HistoryData(DateTimeOffset.Now, line2));
+
+            Config.HistoryData = new DataConfig()
+            {
+                OverlayExistingData = true,
+                Elements =
+                [
+                    new ElementConfig
+                    {
+                        Name = $"{nameof(DataLine.WeatherConditions)}.{nameof(WeatherConditions.WindSpeed)}",
+                        ServiceElements =
+                        [
+                            new ServiceElementConfig { ServiceName = service1Name, Action = "Average", Weight = weight1 },
+                            new ServiceElementConfig { ServiceName = service2Name, Action = "Average", Weight = weight2 }
+                        ]
+                    }
+                ]
+            };
+
+            var dr = GetDataRetriever();
+            var l = new Location("TestLocation");
+
+            var result = await dr.GetHistoryDataAsync(l);
+
+            Assert.IsNotNull(result);
+            var line = result.Lines.First();
+            var ws = line.WeatherConditions!.WindSpeed;
+            Assert.IsNotNull(ws);
+
+            var expected = ((value1 * weight1) + (value2 * weight2)) / (float)(weight1 + weight2);
+            Assert.AreEqual(expected, ws!.To(WindSpeedEnum.MilesPerHour)!.Value, 0.01, "Weighted WindSpeed incorrect.");
+        }
+
+        [TestMethod]
+        public async Task GetHistoryDataAsync_ShouldRaiseHistoryDataUpdatedEventOnSuccessfulRetrieval()
+        {
+            var service = SetupHistoryQueryService("HistoryService");
+            var line = GenerateHistoryLine();
+            service.Setup(s => s.GetHistoryDataAsync(It.IsAny<Location>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
+                .ReturnsAsync(new HistoryData(DateTimeOffset.Now, line));
+
+            Config.HistoryData = GenerateAllStarConfig("HistoryService");
+
+            var dr = GetDataRetriever();
+            var l = new Location("TestLocation");
+
+            var result = await dr.GetHistoryDataAsync(l);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, HistoryDataUpdated.Count, "HistoryDataUpdated should fire once.");
+            Assert.AreEqual(l, HistoryDataUpdated.First().Location, "Event location mismatch.");
+        }
+
+        [TestMethod]
+        public async Task GetHistoryDataAsync_ShouldThrowIfServiceThrowsException()
+        {
+            var service = SetupHistoryQueryService("HistoryService");
+            service.Setup(s => s.GetHistoryDataAsync(It.IsAny<Location>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
+                .ThrowsAsync(new InvalidOperationException("fail"));
+
+            Config.HistoryData = GenerateAllStarConfig("HistoryService");
+
+            var dr = GetDataRetriever();
+            var l = new Location("TestLocation");
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => dr.GetHistoryDataAsync(l));
+            Assert.AreEqual(0, HistoryDataUpdated.Count, "Event should not fire when exception thrown.");
+        }
+
+        [TestMethod]
+        public void HistoryData_PruneOlderThan_ShouldRemoveOlderLines()
+        {
+            var oldLine = GenerateHistoryLine(observed: DateTimeOffset.Now.AddDays(-5));
+            var newLine = GenerateHistoryLine(observed: DateTimeOffset.Now);
+
+            var data = new HistoryData(DateTimeOffset.Now, oldLine, newLine);
+
+            var cutoff = DateTime.Today.AddDays(-2);
+            data.PruneOlderThan(cutoff);
+
+            Assert.AreEqual(1, data.Lines.Count());
+            Assert.IsTrue(data.Lines.All(l => l.Observed >= cutoff));
+        }
+
+        [TestMethod]
+        public async Task GetHistoryDataAsync_ShouldReturnEmptyHistoryDataWhenServicesReturnEmptyLines()
+        {
+            var service = SetupHistoryQueryService("HistoryService");
+            service.Setup(s => s.GetHistoryDataAsync(It.IsAny<Location>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
+                .ReturnsAsync(new HistoryData(DateTimeOffset.Now));
+
+            Config.HistoryData = GenerateAllStarConfig("HistoryService");
+
+            var dr = GetDataRetriever();
+            var l = new Location("TestLocation");
+
+            var result = await dr.GetHistoryDataAsync(l);
+
+            Assert.IsNotNull(result);
+            Assert.IsFalse(result.Lines.Any());
+            Assert.AreEqual(1, HistoryDataUpdated.Count);
+        }
+
+        [TestMethod]
+        public async Task GetHistoryDataAsync_ShouldNotCallServiceAgainIfDataIsValidAndCacheExists()
+        {
+            var service = SetupHistoryQueryService("HistoryService");
+            var line = GenerateHistoryLine();
+            var data = new HistoryData(DateTimeOffset.Now, line);
+
+            service.Setup(s => s.GetHistoryDataAsync(It.IsAny<Location>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
+                .ReturnsAsync(data);
+
+            Config.HistoryData = GenerateAllStarConfig("HistoryService");
+
+            var dr = GetDataRetriever();
+            var l = new Location("TestLocation");
+
+            var first = await dr.GetHistoryDataAsync(l);
+            var second = await dr.GetHistoryDataAsync(l);
+
+            Assert.AreSame(first, second);
+            service.Verify(s => s.GetHistoryDataAsync(It.IsAny<Location>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()), Times.Once());
+        }
+
 
     }
 }


### PR DESCRIPTION
## Summary
- extend `DataRetrieverServiceTests_History` with many new tests
- cover merging, overlay behaviour, weighting of temperatures and weather conditions
- validate caching, event firing, pruning and empty responses

## Testing
- `dotnet test ID.WeatherDashboard.APITests/ID.WeatherDashboard.APITests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687a51f17cd48320a963e6a7c990cb21